### PR TITLE
Propose is-website-vulnerable as a CLI tool to scan websites

### DIFF
--- a/tools/is-website-vulnerable.json
+++ b/tools/is-website-vulnerable.json
@@ -1,0 +1,22 @@
+{
+    "name": "is-website-vulnerable",
+    "description": "finds publicly known security vulnerabilities in a website's frontend JavaScript libraries",
+    "tags": [
+        "security",
+        "website",
+        "scan",
+        "scanner"
+    ],
+    "operating_systems": [
+        "linux",
+        "mac",
+        "windows"
+    ],
+    "license": "Apache-2",
+    "availability": [
+        "opensource",
+        "free",
+    ],
+    "github_url": "https://github.com/lirantal/is-website-vulnerable",
+    "url": "https://github.com/lirantal/is-website-vulnerable"
+}


### PR DESCRIPTION
Propose is-website-vulnerable as a CLI tool to scan websites
for security issues and report it on the terminal.